### PR TITLE
Remove external link to content that no longer exists

### DIFF
--- a/index.md
+++ b/index.md
@@ -69,19 +69,19 @@ In Article 6, the GDPR gives six lawful bases by which data processing can be ju
 
 ## The GDPR in Archives
 
-While archives must comply with the GDPR in the processing of archives user data, the Regulation includes some exceptions and derogations for personal data present in archival collections, since the principles and rights of data minimization and permanent preservation are at odds.[^4] However, these exceptions are somewhat ambiguous and not clearly defined. Additionally, derogations are defined as the ability of EU Member States to further define exceptions, meaning that there can be some variation across the EU on what exceptions are in place for archives (see Bird & Bird’s GDPR legislation tracker).[^5] In a 2017 white paper, archivist Isabel Taylor analyzes the archives-specific section of the GDPR and notes that “the derogations for archives, and how well they will work in practice, currently constitute one of the most uncertain areas of the new law.”[^6] 
+While archives must comply with the GDPR in the processing of archives user data, the Regulation includes some exceptions and derogations for personal data present in archival collections, since the principles and rights of data minimization and permanent preservation are at odds.[^4] However, these exceptions are somewhat ambiguous and not clearly defined. Additionally, derogations are defined as the ability of EU Member States to further define exceptions, meaning that there can be some variation across the EU on what exceptions are in place for archives. In a 2017 white paper, archivist Isabel Taylor analyzes the archives-specific section of the GDPR and notes that “the derogations for archives, and how well they will work in practice, currently constitute one of the most uncertain areas of the new law.”[^5] 
 
-Because of this need for interpretation, archivists active in thinking through GDPR implementation and privacy legislation in general articulate the importance of archival advocacy in these spaces; the integrity and preservation of archival records is threatened by unmitigated data privacy rights. Taylor argues that archival advocacy is “key to entrench an archives-friendly interpretation of the grey areas in the Regulation,”[^7] and in a report on archives legal issues in GDPR for the E-Ark Project, Anderson and Anderson state that it is “vital that archives should not simply become spectators as legislation and regulation is conceived and implemented.”[^8]
+Because of this need for interpretation, archivists active in thinking through GDPR implementation and privacy legislation in general articulate the importance of archival advocacy in these spaces; the integrity and preservation of archival records is threatened by unmitigated data privacy rights. Taylor argues that archival advocacy is “key to entrench an archives-friendly interpretation of the grey areas in the Regulation,”[^6] and in a report on archives legal issues in GDPR for the E-Ark Project, Anderson and Anderson state that it is “vital that archives should not simply become spectators as legislation and regulation is conceived and implemented.”[^7]
  
-Archives professional organizations and data privacy experts are in the early stages of building a common interpretation and approach to GDPR, with the EU leading the way. Recognizing that this legislation is still new, that archives are under the radar right now in terms of GDPR enforcement, and that litigation will influence how practices are determined, a measured approach is appropriate. While the GDPR is new and far-reaching, archivists also already work to balance principles of privacy with the provision of open and equitable access to records.[^9] GDPR does not require a drastic change to archival ethics and best practices.
+Archives professional organizations and data privacy experts are in the early stages of building a common interpretation and approach to GDPR, with the EU leading the way. Recognizing that this legislation is still new, that archives are under the radar right now in terms of GDPR enforcement, and that litigation will influence how practices are determined, a measured approach is appropriate. While the GDPR is new and far-reaching, archivists also already work to balance principles of privacy with the provision of open and equitable access to records.[^8] GDPR does not require a drastic change to archival ethics and best practices.
 
 ### Archival Exemptions and Derogations
 
 The relevant GDPR exceptions provide for “archiving in the public interest” and for “historical research” which are discussed in Article 89(1) and (2), and further clarified in Recital 158.
  
-Recital 158 explains that “archiving in the public interest” applies to organizations that “hold records of public interest” and “have a legal obligation to acquire, preserve, appraise, arrange, describe, communicate, promote, disseminate and provide access to records of enduring value for general public interest.” Therefore, it is the mission of the institution holding the records that is important in determining if the exemption applies.[^10]
+Recital 158 explains that “archiving in the public interest” applies to organizations that “hold records of public interest” and “have a legal obligation to acquire, preserve, appraise, arrange, describe, communicate, promote, disseminate and provide access to records of enduring value for general public interest.” Therefore, it is the mission of the institution holding the records that is important in determining if the exemption applies.[^9]
  
-Article 89(1) states that “processing for archiving purposes in the public interest, scientific or historical research purposes or statistical purposes” are still subject to “appropriate safeguards” for data subjects including that “technical and organizational measures are in place” for the principal of data minimization (principle 3, as described above). However, as the European Archives Group point out, data minimization can be at odds with archival preservation, and the data protection principles note “archiving in the public interest” exceptions as related to the purpose of the data collection and the time period that data can be stored (principles 2 and 5).[^11]
+Article 89(1) states that “processing for archiving purposes in the public interest, scientific or historical research purposes or statistical purposes” are still subject to “appropriate safeguards” for data subjects including that “technical and organizational measures are in place” for the principal of data minimization (principle 3, as described above). However, as the European Archives Group point out, data minimization can be at odds with archival preservation, and the data protection principles note “archiving in the public interest” exceptions as related to the purpose of the data collection and the time period that data can be stored (principles 2 and 5).[^10]
  
 Article 89(3) further provides that where personal data are processed for “archiving purposes in the public interest”, Member State law may provide for derogations from specific data subject rights “in so far as such rights are likely to render impossible or seriously impair the achievement of the specific purposes, and such derogations are necessary for the fulfilment of those purposes.”
  
@@ -138,8 +138,6 @@ Anderson, David and Janet Anderson. “Advice to Archives arising from "E-ARK Le
 
 Ashley, Lori, Sarah R. Demb and Sarit Hand. “Europeans in Mind: GDPR and the Right to be Forgotten in North America.” Session presented at the Society of American Archivists Annual Meeting, August 2019.
 
-Bird & Bird. “GDPR Tracker.” [https://www.twobirds.com/en/in-focus/general-data-protection-regulation/gdpr-tracker](https://www.twobirds.com/en/in-focus/general-data-protection-regulation/gdpr-tracker)
-
 European Archives Group. “Guidance on Data Protection for Archive Services: EAG guidelines on the implementation of the GDPR in the archive sector”. October 2018. [https://ec.europa.eu/info/files/guidance-data-protection-archive-services_en](https://ec.europa.eu/info/files/guidance-data-protection-archive-services_en)
 
 GDPR.eu. “Complete guide to GDPR compliance.” [https://gdpr.eu/](https://gdpr.eu/)
@@ -170,16 +168,14 @@ Your Europe European Union. “Data Protection Under GDPR.” [https://europa.eu
 
 [^4]: European Archives Group. “Guidance on Data Protection for Archive Services: EAG guidelines on the implementation of the GDPR in the archive sector,” 5.
 
-[^5]: Bird & Bird. “GDPR Tracker.”
+[^5]: Taylor, Isabel. “The General Data Protection Regulation: White Paper,” 186.
 
-[^6]: Taylor, Isabel. “The General Data Protection Regulation: White Paper,” 186.
+[^6]: Taylor, 192.
 
-[^7]: Taylor, 192.
+[^7]: Anderson and Anderson. “Advice to Archives arising from "E-ARK Legal Issues Report: European Cultural Preservation in a Changing Legislative Landscape", 12.
 
-[^8]: Anderson and Anderson. “Advice to Archives arising from "E-ARK Legal Issues Report: European Cultural Preservation in a Changing Legislative Landscape", 12.
+[^8]: Society of American Archivists. Code of Ethics for Archivists.
 
-[^9]: Society of American Archivists. Code of Ethics for Archivists.
+[^9]: European Archives Group, 10.
 
-[^10]: European Archives Group, 10.
-
-[^11]: European Archives Group, 5.
+[^10]: European Archives Group, 5.


### PR DESCRIPTION
The Bird & Bird “GDPR Tracker.” [https://www.twobirds.com/en/in-focus/general-data-protection-regulation/gdpr-tracker](https://www.twobirds.com/en/trending-topics/general-data-protection-regulation/gdpr-tracker) is no longer available as a resource. Removes the link and reference to this external page.